### PR TITLE
Fix Bower main field pointing to minified version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-message-format",
   "version": "1.5.7-build.4853+sha.48c8b23",
-  "main": "./angular-message-format.min.js",
+  "main": "./angular-message-format.js",
   "ignore": [],
   "dependencies": {
     "angular": "1.5.7-build.4853+sha.48c8b23"


### PR DESCRIPTION
Getting this error now when installing 1.5.5:

```
bower angular-message-format#1.5.5     invalid-meta The "main" field cannot contain minified files
```

From the [spec](https://github.com/bower/spec/blob/master/json.md#main):

> Do not include minified files.
