### PR TITLE
Import unminified by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require('./angular-message-format.min');
+require('./angular-message-format');
 module.exports = 'ngMessageFormat';


### PR DESCRIPTION
As referenced in:
angular/angular.js#14966
there appears to be some problem with the minified version of angular-message-format, which is exacerbated by
angular/angular#10384
which points out that this repo includes the minified version by default, instead of the pattern seen in other bower-angular packages
