### PR TITLE
chore(index): default to the unminified version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install angular-message-format
 Then add `ngMessageFormat` as a dependency for your app:
 
 ```javascript
-angular.module('myApp', [require('angular-message-format.min')]);
+angular.module('myApp', [require('angular-message-format')]);
 ```
 
 ### bower
@@ -29,7 +29,7 @@ bower install angular-message-format
 Then add a `<script>` to your `index.html`:
 
 ```html
-<script src="/bower_components/angular-message-format/angular-message-format.min.js"></script>
+<script src="/bower_components/angular-message-format/angular-message-format.js"></script>
 ```
 
 Then add `ngMessageFormat` as a dependency for your app:

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-message-format",
   "version": "1.5.9-build.4968+sha.7bef522",
-  "main": "./angular-message-format.min.js",
+  "main": "./angular-message-format.js",
   "ignore": [],
   "dependencies": {
     "angular": "1.5.9-build.4968+sha.7bef522"

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require('./angular-message-format.min');
+require('./angular-message-format');
 module.exports = 'ngMessageFormat';


### PR DESCRIPTION
All other Angular modules default to the unminified version. `ngMessageFormat` should default to that too for consistency and to avoid issues from mixing minified and unminified Angular files (see angular/angular.js#14966).

Closes #2
Closes #3
